### PR TITLE
Update will_paginate dependency version to 3.1.0

### DIFF
--- a/CHANGELOG.mod
+++ b/CHANGELOG.mod
@@ -1,4 +1,6 @@
 # CHANGELOG
+## Version 0.2.0
+* Updated will_paginate dependency to 3.1.0 for compatibility with rails 5.
 
 ## Version 0.1.2
 * Set Materialize to the default LinkRenderer

--- a/lib/materialize_pagination/version.rb
+++ b/lib/materialize_pagination/version.rb
@@ -1,3 +1,3 @@
 module MaterializePagination
-  VERSION = "0.1.2"
+  VERSION = "0.2.0"
 end

--- a/will_paginate-materialize.gemspec
+++ b/will_paginate-materialize.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
 
-  spec.add_dependency "will_paginate", '~> 3.0.6'
+  spec.add_dependency "will_paginate", '~> 3.1.0'
 end


### PR DESCRIPTION
Version of will_paginate that is currently specified has a bug in rails 5 explained here: [](https://github.com/mislav/will_paginate/pull/450) regarding the i18n load path. 

This is fixed in version 3.1.0. 
