### PR TITLE
Updated to create the template shown in the materializecss docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 1. Install [Materialize-sass](https://github.com/mkhairi/materialize-sass) (if you haven't already)
 2. Add the following to your application.scss file
 ```
-.pagination a li.active {
+.pagination li.active a {
   color: #fff;
 }
 ```

--- a/lib/materialize_pagination/materialize_renderer.rb
+++ b/lib/materialize_pagination/materialize_renderer.rb
@@ -27,7 +27,7 @@ module MaterializePagination
       classes = [(classname if @options[:page_links]), ('disabled' unless page)].join(' ')
       chevron_direction = classname == 'previous_page' ? 'left' : 'right'
 
-      tag :li, link("poutsa<i class='material-icons'>chevron_#{chevron_direction}</i>".html_safe, page || '#!'), class: classes
+      tag :li, link("<i class='fa fa-arrow-#{chevron_direction}' aria-hidden='true'>".html_safe, page || '#!'), class: classes
     end
   end
 end

--- a/lib/materialize_pagination/materialize_renderer.rb
+++ b/lib/materialize_pagination/materialize_renderer.rb
@@ -27,7 +27,7 @@ module MaterializePagination
       classes = [(classname if @options[:page_links]), ('disabled' unless page)].join(' ')
       chevron_direction = classname == 'previous_page' ? 'left' : 'right'
 
-      tag :li, link("<i class='material-icons'>chevron_#{chevron_direction}</i>".html_safe, page || '#!'), class: classes
+      tag :li, link("poutsa<i class='material-icons'>chevron_#{chevron_direction}</i>".html_safe, page || '#!'), class: classes
     end
   end
 end

--- a/lib/materialize_pagination/materialize_renderer.rb
+++ b/lib/materialize_pagination/materialize_renderer.rb
@@ -13,8 +13,7 @@ module MaterializePagination
     def page_number(page)
       classes = ['waves-effect', ('active' if page == current_page)].join(' ')
 
-      list_item = tag :li, page, :class => classes
-      link(list_item, page, :rel => rel_value(page))
+      tag :li, link(page, page, :rel => rel_value(page)), :class => classes
     end
 
     # @return [String] rendered gap between pagination links

--- a/lib/materialize_pagination/materialize_renderer.rb
+++ b/lib/materialize_pagination/materialize_renderer.rb
@@ -25,7 +25,7 @@ module MaterializePagination
       classes = [(classname if @options[:page_links]), (page ? 'waves-effect' : 'disabled')].join(' ')
       chevron_direction = classname == 'previous_page' ? 'left' : 'right'
 
-      tag :li, link("<i class='fa fa-chevron-#{chevron_direction}' aria-hidden='true'></i>".html_safe, page || '#!'), class: classes
+      tag :li, link("<i class='material-icons'>chevron_#{chevron_direction}</i>".html_safe, page || '#!'), class: classes
     end
   end
 end

--- a/lib/materialize_pagination/materialize_renderer.rb
+++ b/lib/materialize_pagination/materialize_renderer.rb
@@ -11,12 +11,7 @@ module MaterializePagination
 
     # @return [String] rendered pagination link
     def page_number(page)
-      if page == current_page
-        classes = 'active'
-      else
-        classes = 'waves-effect'
-      end
-
+      classes = page == current_page ? 'active' : 'waves-effect'
       tag :li, link(page, page, :rel => rel_value(page)), :class => classes
     end
 
@@ -27,8 +22,7 @@ module MaterializePagination
 
     # @return [String] rendered previous and next arrow links
     def previous_or_next_page(page, text, classname)
-      disabled_or_active = page ? 'waves-effect' : 'disabled'
-      classes = [(classname if @options[:page_links]), disabled_or_active].join(' ')
+      classes = [(classname if @options[:page_links]), (page ? 'waves-effect' : 'disabled')].join(' ')
       chevron_direction = classname == 'previous_page' ? 'left' : 'right'
 
       tag :li, link("<i class='fa fa-chevron-#{chevron_direction}' aria-hidden='true'></i>".html_safe, page || '#!'), class: classes

--- a/lib/materialize_pagination/materialize_renderer.rb
+++ b/lib/materialize_pagination/materialize_renderer.rb
@@ -11,7 +11,11 @@ module MaterializePagination
 
     # @return [String] rendered pagination link
     def page_number(page)
-      classes = ['waves-effect', ('active' if page == current_page)].join(' ')
+      if page == current_page
+        classes = 'active'
+      else
+        classes = 'waves-effect'
+      end
 
       tag :li, link(page, page, :rel => rel_value(page)), :class => classes
     end

--- a/lib/materialize_pagination/materialize_renderer.rb
+++ b/lib/materialize_pagination/materialize_renderer.rb
@@ -30,7 +30,7 @@ module MaterializePagination
       classes = [(classname if @options[:page_links]), ('disabled' unless page)].join(' ')
       chevron_direction = classname == 'previous_page' ? 'left' : 'right'
 
-      tag :li, link("<i class='fa fa-arrow-#{chevron_direction}' aria-hidden='true'></i>".html_safe, page || '#!'), class: classes
+      tag :li, link("<i class='fa fa-chevron-#{chevron_direction}' aria-hidden='true'></i>".html_safe, page || '#!'), class: classes
     end
   end
 end

--- a/lib/materialize_pagination/materialize_renderer.rb
+++ b/lib/materialize_pagination/materialize_renderer.rb
@@ -27,7 +27,8 @@ module MaterializePagination
 
     # @return [String] rendered previous and next arrow links
     def previous_or_next_page(page, text, classname)
-      classes = [(classname if @options[:page_links]), ('disabled' unless page)].join(' ')
+      disabled_or_active = page ? 'waves-effect' : 'disabled'
+      classes = [(classname if @options[:page_links]), disabled_or_active].join(' ')
       chevron_direction = classname == 'previous_page' ? 'left' : 'right'
 
       tag :li, link("<i class='fa fa-chevron-#{chevron_direction}' aria-hidden='true'></i>".html_safe, page || '#!'), class: classes

--- a/lib/materialize_pagination/materialize_renderer.rb
+++ b/lib/materialize_pagination/materialize_renderer.rb
@@ -27,7 +27,7 @@ module MaterializePagination
       classes = [(classname if @options[:page_links]), ('disabled' unless page)].join(' ')
       chevron_direction = classname == 'previous_page' ? 'left' : 'right'
 
-      tag :li, link("<i class='fa fa-arrow-#{chevron_direction}' aria-hidden='true'>".html_safe, page || '#!'), class: classes
+      tag :li, link("<i class='fa fa-arrow-#{chevron_direction}' aria-hidden='true'></i>".html_safe, page || '#!'), class: classes
     end
   end
 end

--- a/will_paginate-materialize.gemspec
+++ b/will_paginate-materialize.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
 
-  spec.add_dependency "will_paginate", '~> 3.0.6'
+  spec.add_dependency 'will_paginate', '~> 3.1.3'
 end


### PR DESCRIPTION
- Changed the order of li and a tags in materialize_renderer.rb to match the order in the materializecss docs
- Added the waves-effect class in the icons that are not disabled (as shown in the docs)
- Updated readme file to take into account that the <a> tag is not contained within the li tag (although I'm pretty sure it is no longer required)
- Updated the will-paginate gem dependency to the latest version
