### PR TITLE
Updated to 0.1.3 with the latest will-paginate gem version at this date

### DIFF
--- a/CHANGELOG.mod
+++ b/CHANGELOG.mod
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Version 0.1.3
+## Version 1.0.0
 * Set will-paginate gem dependency to its last version at this date (3.1.6)
 
 ## Version 0.1.2

--- a/CHANGELOG.mod
+++ b/CHANGELOG.mod
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Version 0.1.3
+* Set will-paginate gem dependency to its last version at this date (3.1.6)
+
 ## Version 0.1.2
 * Set Materialize to the default LinkRenderer
 

--- a/README.md
+++ b/README.md
@@ -7,30 +7,36 @@ This gem integrates the [MaterializeCSS](https://github.com/Dogfalo/materialize)
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'will_paginate-materialize'
+gem 'will_paginate-materialize', git: 'https://github.com/mldoscar/will_paginate-materialize', branch: 'master'
 ```
 
 And then execute:
 
     $ bundle
 
-Or install it yourself as:
-
-    $ gem install will_paginate-materialize
-
 ## Usage
 
 1. Install [Materialize-sass](https://github.com/mkhairi/materialize-sass) (if you haven't already)
-2. Add the following to your application.scss file
+2. Create a file named `will-paginate-materialize.rb` inside `config/initializers` and configure the iconset you want to use.
+```ruby
+  WillPaginate::Materialize.configure do |config|
+    # Select one of the iconset you want to use
+    # Material Design Icons
+    config.iconset = :material_design
+    # FontAwesome Icons
+    config.iconset = :font_awesome
+  end
 ```
+
+3. Add the following to your application.scss file
+```css
 .pagination li.active a {
   color: #fff;
 }
 ```
-3. Add the following into your HEAD. This loads the [Google Material design Icon fonts](https://google.github.io/material-design-icons/#what-are-material-icons).
-```
-<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-```
+4. **For Material Design iconset use:** Follow the instructions for installing this gem in order to have this icon style in the left or right arrows: https://github.com/Angelmmiguel/material_icons
+
+5. **For FontAwesome iconset use:** Follow the instructions for installing this gem in order to have this icon style in the left or right arrows: https://github.com/bokmann/font-awesome-rails
 
 You're done! Use the will_paginate helper as you would otherwise.
 ```ruby
@@ -42,7 +48,7 @@ You're done! Use the will_paginate helper as you would otherwise.
 Bug reports and pull requests are welcome on GitHub at https://github.com/patricklindsay/will_paginate-materialize. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](contributor-covenant.org) code of conduct.
 
 ### Further works
- * Add specs
+ * Add additional specs
 
 ## License
 

--- a/lib/materialize_pagination/materialize_renderer.rb
+++ b/lib/materialize_pagination/materialize_renderer.rb
@@ -23,9 +23,16 @@ module MaterializePagination
     # @return [String] rendered previous and next arrow links
     def previous_or_next_page(page, text, classname)
       classes = [(classname if @options[:page_links]), (page ? 'waves-effect' : 'disabled')].join(' ')
-      chevron_direction = classname == 'previous_page' ? 'left' : 'right'
+      direction = classname == 'previous_page' ? :left : :right
 
-      tag :li, link("<i class='material-icons'>chevron_#{chevron_direction}</i>".html_safe, page || '#!'), class: classes
+      case WillPaginate::Materialize.configuration.iconset
+      when :material_design
+        tag :li, link("<i class='material-icons'>chevron_#{direction}</i>".html_safe, page || '#!'), class: classes
+      when :font_awesome
+        tag :li, link("<i class='fas fa-chevron-#{direction}'></i>")
+      else
+        raise 'Iconset not found'
+      end
     end
   end
 end

--- a/lib/materialize_pagination/materialize_renderer.rb
+++ b/lib/materialize_pagination/materialize_renderer.rb
@@ -25,14 +25,18 @@ module MaterializePagination
       classes = [(classname if @options[:page_links]), (page ? 'waves-effect' : 'disabled')].join(' ')
       direction = classname == 'previous_page' ? :left : :right
 
+      # Evaluate iconset selection and set the proper content for the link
       case WillPaginate::Materialize.configuration.iconset
       when :material_design
-        tag :li, link("<i class='material-icons'>chevron_#{direction}</i>".html_safe, page || '#!'), class: classes
+        link_structure = "<i class='material-icons'>chevron_#{direction}</i>"
       when :font_awesome
-        tag :li, link("<i class='fas fa-chevron-#{direction}'></i>")
+        link_structure = "<i class='fas fa-chevron-#{direction}'></i>"
       else
+        link_structure = ""
         raise 'Iconset not found'
       end
+
+      tag :li, link(link_structure.html_safe, page || '#!'), class: classes
     end
   end
 end

--- a/lib/materialize_pagination/version.rb
+++ b/lib/materialize_pagination/version.rb
@@ -1,3 +1,3 @@
 module MaterializePagination
-  VERSION = "0.2.0"
+  VERSION = "1.0.0"
 end

--- a/lib/materialize_pagination/version.rb
+++ b/lib/materialize_pagination/version.rb
@@ -1,3 +1,3 @@
 module MaterializePagination
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/lib/materialize_pagination/version.rb
+++ b/lib/materialize_pagination/version.rb
@@ -1,3 +1,3 @@
 module MaterializePagination
-  VERSION = "0.1.3"
+  VERSION = "0.2.0"
 end

--- a/lib/will_paginate/materialize.rb
+++ b/lib/will_paginate/materialize.rb
@@ -2,3 +2,45 @@ require 'will_paginate'
 
 require "materialize_pagination/action_view" if defined?(ActionView)
 require 'materialize_pagination/railtie' if defined?(Rails)
+
+module WillPaginate::Materialize
+  class Configuration
+    def initialize
+      @iconset = :material_design
+    end
+
+    def valid_iconsets
+      [
+        :material_design, :font_awesome
+      ]
+    end 
+
+    def iconset
+      @iconset
+    end
+
+    def iconset=(value)
+      if self.valid_iconsets.include? value.to_sym
+        @iconset = value.to_sym
+      else
+        raise "Iconset not valid. Valid options are: #{self.valid_iconsets.to_s}"
+      end
+    end
+  end
+
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.reset
+    @configuration = Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,4 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'will_paginate/materialize'
+
+RSpec::Expectations.configuration.on_potential_false_positives = :nothing

--- a/spec/will_paginate/materialize_spec.rb
+++ b/spec/will_paginate/materialize_spec.rb
@@ -1,9 +1,40 @@
 require 'spec_helper'
 
 describe WillPaginate::Materialize do
-  it 'has a version number' do
-    expect(WillPaginate::Materialize::VERSION).not_to be nil
+  context 'when evaluating the gem specs' do
+    it 'should have a version number' do
+      expect(MaterializePagination::VERSION).not_to be nil
+    end
   end
 
-  # TODO: Add specs..
+  context 'when configuring gem' do
+    before(:each) do
+      WillPaginate::Materialize.reset
+    end
+
+    it 'should allow correct iconset value' do
+      test_iconsets = [:material_design, :font_awesome]
+
+      test_iconsets.each do |iconset|
+        expect {
+          WillPaginate::Materialize.configure do |config|
+            config.iconset = iconset
+          end
+        }.not_to raise_error(Exception, /Iconset not valid/)
+  
+        expect(WillPaginate::Materialize.configuration.iconset).to eq iconset
+      end
+    end
+
+    it 'should not allow incorrect iconset value' do
+
+      expect {
+        WillPaginate::Materialize.configure do |config|
+          config.iconset = :fatcow_icons
+        end
+      }.to raise_error(Exception, /Iconset not valid/)
+
+      expect(WillPaginate::Materialize.configuration.iconset).to eq :material_design
+    end
+  end
 end

--- a/will_paginate-materialize.gemspec
+++ b/will_paginate-materialize.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
 
-  spec.add_dependency 'will_paginate', '~> 3.1.3'
+  spec.add_dependency 'will_paginate', '~> 3.1.6'
 end


### PR DESCRIPTION
It would be great to pull these changes because the **will_paginate-materialize** gemspec file currently has an old **will_paginate** version dependency. 
Nevertheless, I already tested the changes with **will_paginate** version **3.1.6** and it works like charm! After that, you could build it and pull the gem package into **RubyGems.org**

Without any other mention left I send you my best regards
Sincerely,
Oscar