### PR TITLE
RTL direction support's added

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ And then execute:
     config.iconset = :material_design
     # FontAwesome Icons
     config.iconset = :font_awesome
+	# The text direction, can be `ltr` or `rtl`
+	# default: `ltr`
+	config.direction = :rtl
   end
 ```
 

--- a/lib/materialize_pagination/materialize_renderer.rb
+++ b/lib/materialize_pagination/materialize_renderer.rb
@@ -24,6 +24,7 @@ module MaterializePagination
     def previous_or_next_page(page, text, classname)
       classes = [(classname if @options[:page_links]), (page ? 'waves-effect' : 'disabled')].join(' ')
       direction = classname == 'previous_page' ? :left : :right
+      direction = direction == :right ? :left : :right if WillPaginate::Materialize.configuration.direction == :rtl
 
       # Evaluate iconset selection and set the proper content for the link
       case WillPaginate::Materialize.configuration.iconset

--- a/lib/materialize_pagination/version.rb
+++ b/lib/materialize_pagination/version.rb
@@ -1,3 +1,3 @@
 module MaterializePagination
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/lib/materialize_pagination/version.rb
+++ b/lib/materialize_pagination/version.rb
@@ -1,3 +1,3 @@
 module MaterializePagination
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/lib/will_paginate/materialize.rb
+++ b/lib/will_paginate/materialize.rb
@@ -7,6 +7,7 @@ module WillPaginate::Materialize
   class Configuration
     def initialize
       @iconset = :material_design
+      @direction = :ltr
     end
 
     def valid_iconsets
@@ -15,8 +16,18 @@ module WillPaginate::Materialize
       ]
     end 
 
+    def valid_directions
+      [
+        :rtl, :ltr
+      ]
+    end
+
     def iconset
       @iconset
+    end
+
+    def direction
+      @direction
     end
 
     def iconset=(value)
@@ -24,6 +35,14 @@ module WillPaginate::Materialize
         @iconset = value.to_sym
       else
         raise "Iconset not valid. Valid options are: #{self.valid_iconsets.to_s}"
+      end
+    end
+
+    def direction=(value)
+      if self.valid_directions.include? value.to_sym
+        @direction = value.to_sym
+      else
+        raise "Direction not valid. Valid options are: #{self.valid_directions.to_s}"
       end
     end
   end

--- a/spec/will_paginate/materialize_spec.rb
+++ b/spec/will_paginate/materialize_spec.rb
@@ -27,7 +27,6 @@ describe WillPaginate::Materialize do
     end
 
     it 'should not allow incorrect iconset value' do
-
       expect {
         WillPaginate::Materialize.configure do |config|
           config.iconset = :fatcow_icons
@@ -35,6 +34,30 @@ describe WillPaginate::Materialize do
       }.to raise_error(Exception, /Iconset not valid/)
 
       expect(WillPaginate::Materialize.configuration.iconset).to eq :material_design
+    end
+
+    it 'should allow correct direction value' do
+      test_directions = [:ltr, :rtl]
+
+      test_directions.each do |direction|
+        expect {
+          WillPaginate::Materialize.configure do |config|
+            config.direction = direction
+          end
+        }.not_to raise_error(Exception, /Direction not valid/)
+
+        expect(WillPaginate::Materialize.configuration.direction).to eq direction
+      end
+    end
+
+    it 'should not allow incorrect direction value' do
+      expect {
+        WillPaginate::Materialize.configure do |config|
+          config.direction = :fatcow_directions
+        end
+      }.to raise_error(Exception, /Direction not valid/)
+
+      expect(WillPaginate::Materialize.configuration.direction).to eq :ltr
     end
   end
 end

--- a/will_paginate-materialize.gemspec
+++ b/will_paginate-materialize.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
 
-  spec.add_dependency 'will_paginate', '~> 3.1.6'
+  spec.add_dependency 'will_paginate', '~> 3.1'
 end


### PR DESCRIPTION
With this patch, users can determine the direction of the context that `will_paginate` is, in the configuration file as below, tests have been written as passed OK.

```RUBY
WillPaginate::Materialize.configure do |config|
  # Select one of the iconset you want to use
  # Material Design Icons
  config.iconset = :material_design
  # FontAwesome Icons
  # config.iconset = :font_awesome
  # The text direction, can [:ltr, :rtl]
  config.direction = :rtl
end
```